### PR TITLE
feat(sprint-15): Peer Accountability Network [13pts]

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/App.kt
+++ b/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/App.kt
@@ -22,6 +22,7 @@ private val navItems = listOf(
     NavItem("📊", "Stats"),
     NavItem("🧘", "Break"),
     NavItem("💼", "Work"),
+    NavItem("🤝", "Peers"),
 )
 
 @Composable
@@ -43,6 +44,8 @@ fun App(viewModel: FocusTimerViewModel) {
         val dashboardViewModel = remember { DashboardViewModel(repository) }
         val breakCoachViewModel = remember { BreakCoachViewModel(focusTimerViewModel = viewModel) }
         val workspaceViewModel = remember { WorkspaceViewModel() }
+        val peerNetworkService = remember { PeerNetworkService(viewModel) }
+        val peerViewModel = remember { PeerViewModel(peerNetworkService) }
 
         Row(modifier = Modifier.fillMaxSize()) {
             NavigationRail {
@@ -67,6 +70,7 @@ fun App(viewModel: FocusTimerViewModel) {
                     }
                     5 -> BreakCoachScreen(breakCoachViewModel)
                     6 -> WorkspaceScreen(workspaceViewModel)
+                    7 -> PeerScreen(peerViewModel)
                 }
             }
         }

--- a/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/Peer.kt
+++ b/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/Peer.kt
@@ -1,0 +1,23 @@
+package org.coding.afternoon.focus
+
+enum class PeerStatus { IDLE, FOCUSING, ON_BREAK }
+
+data class Peer(
+    val id: String,
+    val displayName: String,
+    val status: PeerStatus,
+    val focusingForMinutes: Int = 0,
+    val lastSeen: Long = System.currentTimeMillis()
+) {
+    val isStale: Boolean get() = System.currentTimeMillis() - lastSeen > 90_000L
+    val statusEmoji: String get() = when (status) {
+        PeerStatus.IDLE -> "😴"
+        PeerStatus.FOCUSING -> "🔥"
+        PeerStatus.ON_BREAK -> "☕"
+    }
+    val statusLabel: String get() = when (status) {
+        PeerStatus.IDLE -> "Idle"
+        PeerStatus.FOCUSING -> "Focusing (${focusingForMinutes}m)"
+        PeerStatus.ON_BREAK -> "On Break"
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/PeerNetworkService.kt
+++ b/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/PeerNetworkService.kt
@@ -1,0 +1,115 @@
+package org.coding.afternoon.focus
+
+import kotlinx.coroutines.*
+import java.net.*
+import java.util.prefs.Preferences
+
+class PeerNetworkService(private val timerViewModel: FocusTimerViewModel) {
+    companion object {
+        private const val MULTICAST_GROUP = "239.255.42.42"
+        private const val PORT = 9877
+        private const val BROADCAST_INTERVAL_MS = 30_000L
+    }
+
+    private val prefs = Preferences.userNodeForPackage(PeerNetworkService::class.java)
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var sendJob: Job? = null
+    private var receiveJob: Job? = null
+    private var socket: MulticastSocket? = null
+
+    val selfId: String = prefs.get("peer_id", java.util.UUID.randomUUID().toString().also {
+        prefs.put("peer_id", it)
+    })
+
+    var displayName: String
+        get() = prefs.get("display_name", System.getProperty("user.name") ?: "Focus User")
+        set(value) { prefs.put("display_name", value) }
+
+    private val peerListeners = mutableListOf<(List<Peer>) -> Unit>()
+    private val peers = mutableMapOf<String, Peer>()
+
+    fun addPeerListener(listener: (List<Peer>) -> Unit) { peerListeners.add(listener) }
+
+    fun start() {
+        try {
+            socket = MulticastSocket(PORT).apply {
+                val group = InetSocketAddress(InetAddress.getByName(MULTICAST_GROUP), PORT)
+                val ni = NetworkInterface.getByInetAddress(InetAddress.getLocalHost())
+                joinGroup(group, ni)
+                soTimeout = 5000
+            }
+            startReceiving()
+            startBroadcasting()
+        } catch (_: Exception) {}
+    }
+
+    fun stop() {
+        sendJob?.cancel()
+        receiveJob?.cancel()
+        try { socket?.close() } catch (_: Exception) {}
+        socket = null
+    }
+
+    private fun buildMessage(): String {
+        val status = when {
+            timerViewModel.timerState == TimerState.Running && timerViewModel.currentPhase == TimerPhase.Focus -> "FOCUSING"
+            timerViewModel.timerState == TimerState.Running && timerViewModel.currentPhase == TimerPhase.Break -> "ON_BREAK"
+            else -> "IDLE"
+        }
+        val elapsed = (timerViewModel.totalSeconds - timerViewModel.remainingSeconds) / 60
+        return """{"id":"$selfId","name":"${displayName.replace("\"", "")}","status":"$status","minutes":$elapsed}"""
+    }
+
+    private fun parseMessage(json: String): Peer? {
+        return try {
+            val id = json.substringAfter("\"id\":\"").substringBefore("\"")
+            val name = json.substringAfter("\"name\":\"").substringBefore("\"")
+            val statusStr = json.substringAfter("\"status\":\"").substringBefore("\"")
+            val minutes = json.substringAfter("\"minutes\":").substringBefore("}").trim().toIntOrNull() ?: 0
+            val status = when (statusStr) {
+                "FOCUSING" -> PeerStatus.FOCUSING
+                "ON_BREAK" -> PeerStatus.ON_BREAK
+                else -> PeerStatus.IDLE
+            }
+            if (id == selfId) null else Peer(id, name, status, minutes)
+        } catch (_: Exception) { null }
+    }
+
+    private fun startBroadcasting() {
+        sendJob = scope.launch {
+            while (isActive) {
+                try {
+                    val msg = buildMessage().toByteArray()
+                    val packet = DatagramPacket(msg, msg.size, InetAddress.getByName(MULTICAST_GROUP), PORT)
+                    socket?.send(packet)
+                } catch (_: Exception) {}
+                delay(BROADCAST_INTERVAL_MS)
+            }
+        }
+    }
+
+    private fun startReceiving() {
+        receiveJob = scope.launch {
+            val buf = ByteArray(1024)
+            while (isActive) {
+                try {
+                    val packet = DatagramPacket(buf, buf.size)
+                    socket?.receive(packet)
+                    val msg = String(packet.data, 0, packet.length)
+                    parseMessage(msg)?.let { peer ->
+                        peers[peer.id] = peer
+                        cleanStalePeers()
+                        val current = peers.values.filter { !it.isStale }.toList()
+                        withContext(Dispatchers.Main) { peerListeners.forEach { it(current) } }
+                    }
+                } catch (_: SocketTimeoutException) {
+                    cleanStalePeers()
+                } catch (_: Exception) {}
+            }
+        }
+    }
+
+    private fun cleanStalePeers() {
+        peers.entries.removeIf { it.value.isStale }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/PeerScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/PeerScreen.kt
@@ -1,0 +1,146 @@
+package org.coding.afternoon.focus
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun PeerScreen(viewModel: PeerViewModel) {
+    val peers = viewModel.peers
+    val isActive = viewModel.isBroadcasting
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        // Your profile card
+        item {
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = if (isActive) Color(0xFFE8F5E9) else Color(0xFFFAFAFA)
+                )
+            ) {
+                Column(
+                    modifier = Modifier.padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text("👤 Your Profile", fontWeight = FontWeight.Bold, fontSize = 16.sp)
+                    OutlinedTextField(
+                        value = viewModel.nameInput,
+                        onValueChange = { viewModel.updateNameInput(it) },
+                        label = { Text("Display Name") },
+                        modifier = Modifier.fillMaxWidth(),
+                        enabled = !isActive,
+                        singleLine = true
+                    )
+                    Button(
+                        onClick = { if (isActive) viewModel.stopBroadcasting() else viewModel.startBroadcasting() },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (isActive) Color(0xFFE53935) else Color(0xFF43A047)
+                        ),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(if (isActive) "🔴 Stop Broadcasting" else "🟢 Start Broadcasting")
+                    }
+                    if (isActive) {
+                        Text(
+                            "Broadcasting as: ${viewModel.displayName}",
+                            fontSize = 12.sp,
+                            color = Color.Gray
+                        )
+                    }
+                }
+            }
+        }
+
+        // Peers section header
+        item {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    "🌐 Peers on Network (${peers.size})",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp
+                )
+            }
+        }
+
+        // Empty state
+        if (peers.isEmpty()) {
+            item {
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Box(
+                        modifier = Modifier.padding(32.dp).fillMaxWidth(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text("🔍", fontSize = 32.sp)
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                if (isActive) "Searching for peers..." else "Start broadcasting to see peers",
+                                color = Color.Gray
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Peer cards
+        items(peers) { peer ->
+            val statusColor = when (peer.status) {
+                PeerStatus.FOCUSING -> Color(0xFF4CAF50)
+                PeerStatus.ON_BREAK -> Color(0xFF2196F3)
+                PeerStatus.IDLE -> Color.Gray
+            }
+            Card(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.padding(16.dp).fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(peer.statusEmoji, fontSize = 24.sp)
+                        Spacer(Modifier.width(12.dp))
+                        Column {
+                            Text(peer.displayName, fontWeight = FontWeight.SemiBold)
+                            Text(peer.statusLabel, fontSize = 12.sp, color = Color.Gray)
+                        }
+                    }
+                    Surface(color = statusColor, shape = RoundedCornerShape(12.dp)) {
+                        Text(
+                            peer.status.name,
+                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
+                            color = Color.White,
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+            }
+        }
+
+        // Info footer
+        item {
+            Text(
+                "ℹ️ Peers are discovered automatically on your local network. No internet connection required.",
+                fontSize = 12.sp,
+                color = Color.Gray,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/PeerViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/org/coding/afternoon/focus/PeerViewModel.kt
@@ -1,0 +1,35 @@
+package org.coding.afternoon.focus
+
+import androidx.compose.runtime.*
+import androidx.lifecycle.ViewModel
+
+class PeerViewModel(private val networkService: PeerNetworkService) : ViewModel() {
+    var peers by mutableStateOf<List<Peer>>(emptyList())
+        private set
+    var isBroadcasting by mutableStateOf(false)
+        private set
+    var displayName by mutableStateOf(networkService.displayName)
+    var nameInput by mutableStateOf(networkService.displayName)
+
+    init {
+        networkService.addPeerListener { updatedPeers ->
+            peers = updatedPeers
+        }
+    }
+
+    fun startBroadcasting() {
+        if (isBroadcasting) return
+        networkService.displayName = nameInput.trim().ifBlank { "Focus User" }
+        displayName = networkService.displayName
+        networkService.start()
+        isBroadcasting = true
+    }
+
+    fun stopBroadcasting() {
+        networkService.stop()
+        isBroadcasting = false
+        peers = emptyList()
+    }
+
+    fun updateNameInput(v: String) { nameInput = v }
+}

--- a/docs/sprints/sprint-15/designer.md
+++ b/docs/sprints/sprint-15/designer.md
@@ -1,0 +1,64 @@
+# Sprint 15 — Design Spec: Peer Accountability Network
+
+## Screen: PeerScreen
+
+### Layout Overview
+```
+┌─────────────────────────────────────────┐
+│  👤 Your Profile                        │
+│  ┌─────────────────────────────────┐    │
+│  │ Display Name  [Alice          ] │    │
+│  └─────────────────────────────────┘    │
+│  [ 🟢 Start Broadcasting           ]    │
+│                                         │
+├─────────────────────────────────────────┤
+│  🌐 Peers on Network (2)                │
+│                                         │
+│  ┌─────────────────────────────────┐    │
+│  │ 🔥 Bob          [FOCUSING] green│    │
+│  │    Focusing (12m)               │    │
+│  └─────────────────────────────────┘    │
+│  ┌─────────────────────────────────┐    │
+│  │ ☕ Carol        [ON_BREAK] blue │    │
+│  │    On Break                     │    │
+│  └─────────────────────────────────┘    │
+│                                         │
+│  ℹ️ Peers are discovered automatically… │
+└─────────────────────────────────────────┘
+```
+
+### Component Details
+
+#### Your Profile Card
+- **Background**: Light green (`0xFFE8F5E9`) when broadcasting, off-white (`0xFFFAFAFA`) when private
+- **Name field**: `OutlinedTextField`, disabled while broadcasting to prevent mid-session name changes
+- **Toggle button**: Full-width, green (`0xFF43A047`) when stopped, red (`0xFFE53935`) when active
+- **Broadcast label**: Small gray text showing "Broadcasting as: {name}" when active
+
+#### Peers List
+- Section header: bold 18sp with live count `🌐 Peers on Network (N)`
+- Each peer rendered as a `Card` with horizontal layout:
+  - Left: status emoji (24sp) + name (SemiBold) + status label (12sp gray)
+  - Right: colored pill badge with status name
+
+#### Status Colors
+| Status | Emoji | Badge Color |
+|---|---|---|
+| `IDLE` | 😴 | Gray |
+| `FOCUSING` | 🔥 | `#4CAF50` (green) |
+| `ON_BREAK` | ☕ | `#2196F3` (blue) |
+
+#### Empty State
+- Centered within a Card
+- Large search emoji 🔍 (32sp)
+- Context-sensitive message:
+  - Not broadcasting: "Start broadcasting to see peers"
+  - Broadcasting: "Searching for peers..."
+
+#### Footer
+- 12sp gray italic info text explaining LAN-only nature
+
+### Interaction Design
+- All state changes are immediate (no loading spinners needed for toggle)
+- Name field auto-trims whitespace on broadcast start
+- Blank name defaults to "Focus User"

--- a/docs/sprints/sprint-15/qa.md
+++ b/docs/sprints/sprint-15/qa.md
@@ -1,0 +1,51 @@
+# Sprint 15 — QA Report: Peer Accountability Network
+
+## Build Results
+
+| Step | Result |
+|---|---|
+| `compileKotlinJvm` (JBR-21.0.9) | ✅ BUILD SUCCESSFUL |
+| Warnings | 0 (deprecated `joinGroup(InetAddress)` fixed to `joinGroup(InetSocketAddress, NetworkInterface)`) |
+| Errors | 0 |
+
+> Note: The default system JDK (OpenJDK 25.0.2 Homebrew) triggers a Kotlin compiler bug with version string parsing. Build must use JBR-21.0.9 or the project's `org.gradle.java.home` override.
+
+## QA Checklist
+
+### Navigation
+- [x] "🤝 Peers" tab appears as 8th item in NavigationRail
+- [x] Tab renders `PeerScreen` correctly (tab index 7)
+
+### Your Profile Card
+- [x] Display Name field is editable when not broadcasting
+- [x] Display Name field is disabled while broadcasting
+- [x] Blank name defaults to "Focus User" on broadcast start
+- [x] Button label switches: "🟢 Start Broadcasting" ↔ "🔴 Stop Broadcasting"
+- [x] Card background turns green (0xFFE8F5E9) when broadcasting
+- [x] "Broadcasting as: {name}" label appears when active
+
+### Peers List
+- [x] Header shows live count: "🌐 Peers on Network (N)"
+- [x] Empty state card shown when peers list is empty
+- [x] Empty state message changes based on broadcast state
+- [x] Each peer card displays: emoji, name, status label, colored badge
+- [x] FOCUSING badge: green (#4CAF50)
+- [x] ON_BREAK badge: blue (#2196F3)
+- [x] IDLE badge: gray
+
+### Network Service (manual/integration)
+- [ ] Two machines on same LAN discover each other within 30s
+- [ ] Status updates propagate within one 30s cycle
+- [ ] Stale peers (90s) removed automatically
+- [ ] User's own broadcast message is ignored (UUID filter)
+- [ ] Stop broadcasting clears the peer list immediately
+- [ ] App continues functioning normally if network is unavailable
+
+### Privacy
+- [x] No internet calls — UDP multicast is LAN-layer only
+- [x] No accounts or credentials
+- [x] Feature is completely opt-in (inactive until "Start Broadcasting" pressed)
+
+## Known Issues / Follow-ups
+- Multicast may be blocked on some corporate or managed Wi-Fi networks (expected limitation, documented in rd.md)
+- `NetworkInterface.getByInetAddress(InetAddress.getLocalHost())` may return `null` on some multi-homed setups — wrapped in try/catch so service gracefully fails to start rather than crashing

--- a/docs/sprints/sprint-15/rd.md
+++ b/docs/sprints/sprint-15/rd.md
@@ -1,0 +1,68 @@
+# Sprint 15 — Engineering Design: Peer Accountability Network
+
+## Architecture
+
+```
+PeerScreen (Compose UI)
+    └── PeerViewModel (state holder, ViewModel)
+            └── PeerNetworkService (background service)
+                    ├── MulticastSocket (send loop, 30s interval)
+                    └── MulticastSocket (receive loop, 5s timeout)
+```
+
+## PeerNetworkService
+
+### UDP Multicast
+- **Group**: `239.255.42.42` (administratively-scoped site-local)
+- **Port**: `9877`
+- `MulticastSocket(PORT)` bound on all interfaces
+- `joinGroup(InetAddress.getByName(MULTICAST_GROUP))` on start
+- `soTimeout = 5000ms` prevents blocking forever on receive
+
+### Send Loop (Coroutine, Dispatchers.IO)
+1. Build JSON message from current `FocusTimerViewModel` state
+2. Create `DatagramPacket` to multicast group
+3. `socket.send(packet)`
+4. `delay(30_000)`
+5. Repeat while coroutine active; all exceptions swallowed to prevent crash
+
+### Receive Loop (Coroutine, Dispatchers.IO)
+1. `socket.receive(packet)` — blocks up to 5s (soTimeout)
+2. On `SocketTimeoutException`: run `cleanStalePeers()`, continue
+3. On valid packet: parse JSON → `Peer?`
+4. Filter own messages by UUID comparison
+5. Update in-memory `peers: MutableMap<String, Peer>`
+6. `withContext(Dispatchers.Main)` to notify listeners (Compose state update)
+
+### Peer Expiry
+- `Peer.lastSeen = System.currentTimeMillis()` set on every received packet
+- `cleanStalePeers()` removes entries where `isStale` is true (`lastSeen > 90s ago`)
+- Called on every timeout cycle and after every valid receive
+
+### Persistence (java.util.prefs.Preferences)
+- `peer_id`: stable UUID generated once, persisted across launches
+- `display_name`: user's chosen display name
+
+## PeerViewModel
+- Wraps `PeerNetworkService`
+- Exposes `peers: List<Peer>` as Compose `mutableStateOf`
+- Exposes `isBroadcasting`, `nameInput`, `displayName` as state
+- `startBroadcasting()` / `stopBroadcasting()` delegate to service
+
+## JSON Parsing
+No external JSON library — simple `String.substringAfter/Before` parsing:
+```kotlin
+val id = json.substringAfter("\"id\":\"").substringBefore("\"")
+```
+Sufficient for the controlled message format we generate ourselves.
+
+## Threading Model
+- All network I/O: `Dispatchers.IO`
+- Compose state updates: `withContext(Dispatchers.Main)`
+- `SupervisorJob` ensures one coroutine failure doesn't cancel others
+- Socket closed in `stop()` to interrupt blocking receive
+
+## Known Limitations
+- Single `MulticastSocket` shared for send/receive (works on macOS; some restrictive corporate firewalls block multicast)
+- No encryption (acceptable: LAN-only, no sensitive data beyond name and focus state)
+- No peer authentication (by design: open trust model on private networks)

--- a/docs/sprints/sprint-15/spec.md
+++ b/docs/sprints/sprint-15/spec.md
@@ -1,0 +1,58 @@
+# Sprint 15 — Product Spec: Peer Accountability Network
+
+## User Stories
+
+| ID | Story | Priority |
+|---|---|---|
+| P15-1 | As a user, I can enter a display name so peers can identify me on the network | Must |
+| P15-2 | As a user, I can toggle broadcasting on/off so I control when my status is visible | Must |
+| P15-3 | As a user, I can see a live list of peers on the same LAN with their current status | Must |
+| P15-4 | As a user, I can see how long a peer has been focusing so I can join or respect their session | Should |
+| P15-5 | As a user, stale peers (not seen for 90s) disappear automatically so the list stays accurate | Must |
+| P15-6 | As a user, no data is sent outside my local network so my privacy is guaranteed | Must |
+
+## Data Model
+
+```kotlin
+enum class PeerStatus { IDLE, FOCUSING, ON_BREAK }
+
+data class Peer(
+    val id: String,              // stable UUID, stored in Preferences
+    val displayName: String,     // user-entered name
+    val status: PeerStatus,      // current timer state
+    val focusingForMinutes: Int, // elapsed focus minutes (0 if not focusing)
+    val lastSeen: Long           // System.currentTimeMillis() of last received broadcast
+) {
+    val isStale: Boolean get() = System.currentTimeMillis() - lastSeen > 90_000L
+}
+```
+
+## Network Protocol
+
+| Property | Value |
+|---|---|
+| Transport | UDP multicast |
+| Multicast group | `239.255.42.42` |
+| Port | `9877` |
+| Broadcast interval | Every 30 seconds |
+| Peer expiry | 90 seconds since last message |
+
+### Message Format (JSON, max ~256 bytes)
+```json
+{"id":"550e8400-e29b-41d4-a716-446655440000","name":"Alice","status":"FOCUSING","minutes":15}
+```
+
+### Status Values
+- `"IDLE"` — timer not running
+- `"FOCUSING"` — timer running in Focus phase
+- `"ON_BREAK"` — timer running in Break phase
+
+## Acceptance Criteria
+
+- [ ] Toggling "Start Broadcasting" begins UDP multicast and shows broadcast label
+- [ ] Display name field is editable only when not broadcasting
+- [ ] Peers list updates within 30 seconds of a peer changing status
+- [ ] Peers not heard from in 90+ seconds are removed from the list
+- [ ] The user's own messages are ignored (filtered by UUID)
+- [ ] Stopping broadcast clears the peers list immediately
+- [ ] App compiles and navigation tab "🤝 Peers" is reachable

--- a/docs/sprints/sprint-15/stakeholder.md
+++ b/docs/sprints/sprint-15/stakeholder.md
@@ -1,0 +1,25 @@
+# Sprint 15 — Stakeholder Brief: Peer Accountability Network
+
+## User Problem
+Remote workers and distributed study groups want to maintain shared focus rituals — the same way co-located teams hold each other accountable through visible presence. Today there is no way to see whether a teammate is currently focusing, on break, or idle without sending a message and interrupting them. Existing solutions require cloud accounts, subscriptions, or complex setup.
+
+## Proposed Feature: Peer Accountability Network
+A **zero-configuration, privacy-first, LAN-only** peer discovery and status-sharing system built directly into the Focus app.
+
+### Core Capabilities
+| Capability | Description |
+|---|---|
+| Zero-config discovery | Detect other Focus users on the same Wi-Fi/LAN with no manual IP entry |
+| Real-time status | See peers' current state: Idle / Focusing / On Break |
+| Focus duration | Know how long a peer has been in a focus session |
+| Opt-in broadcasting | Users choose to share their status; off by default |
+| Privacy-first | Absolutely no data leaves the local network; no accounts; no cloud |
+
+## Story Points
+**13 (Fibonacci)** — significant network infrastructure, background service lifecycle, and UI work.
+
+## Success Criteria
+1. Two macOS machines on the same LAN can see each other's focus status within 60 seconds of both starting broadcasts.
+2. Stopping broadcast immediately removes the user from peers' view (within one 90-second expiry cycle).
+3. The feature is entirely opt-in — the app works normally if the user never touches the Peers tab.
+4. No external services, accounts, or internet connection are required.


### PR DESCRIPTION
## 🤝 Peer Accountability Network

**Sprint 15 | Story Points: 13 | Team Epsilon**

### 📋 Overview
Zero-config LAN peer discovery using UDP multicast. Users on the same network can see each other's focus status in real-time — no accounts, no internet, no setup.

### ✨ Features
- **Auto Discovery**: UDP multicast on `239.255.42.42:9877`, broadcasts every 30s
- **Real-time Status**: IDLE 😴 / FOCUSING 🔥 / ON_BREAK ☕ with color badges
- **Privacy First**: Opt-in toggle, LAN-only, no cloud, no accounts
- **Peer Expiry**: Peers auto-removed after 90s of silence
- **Display Name**: Editable username stored in Preferences
- **Empty State**: Clear guidance when no peers found
- **Graceful Degradation**: All network exceptions silently swallowed

### 📁 Files Added
- `Peer.kt` — Data model + PeerStatus enum
- `PeerNetworkService.kt` — UDP multicast send/receive with coroutines
- `PeerViewModel.kt` — Compose state bridge
- `PeerScreen.kt` — Profile card + live peer list
- `App.kt` — Added 🤝 Peers tab
- `docs/sprints/sprint-15/` — stakeholder.md, spec.md, designer.md, rd.md, qa.md

### ✅ QA
- Build: `compileKotlinJvm` **SUCCESSFUL** (0 errors, 0 warnings)